### PR TITLE
Update tasks before getting an API response

### DIFF
--- a/src/services/store/modules/group.js
+++ b/src/services/store/modules/group.js
@@ -22,6 +22,7 @@ const getters = {
 
     return undoneTasks.concat(doneTasks);
   },
+  task: (state, getters) => taskId => getters.tasks.find(task => task.id === taskId),
   loadingGroup(state) {
     return state.loadingGroup;
   },
@@ -103,9 +104,22 @@ const actions = {
 
     dispatch('updateTask', task);
   },
-  async updateTask({commit}, task) {
-    const updatedTask = await API.tasks.update(task.id, task);
-    commit('updateTask', updatedTask);
+  async updateTask({commit, getters}, task) {
+    const actualTask = getters.task(task.id);
+
+    const earlyTask = {
+      ...actualTask,
+      ...task,
+    };
+
+    commit('updateTask', earlyTask);
+
+    try {
+      const updatedTask = await API.tasks.update(task.id, task);
+      commit('updateTask', updatedTask);
+    } catch (e) {
+      commit('updateTask', actualTask);
+    }
   }
 };
 

--- a/tests/unit/services/store/modules/group/actions.spec.js
+++ b/tests/unit/services/store/modules/group/actions.spec.js
@@ -1,4 +1,5 @@
 import {actions} from '@/services/store/modules/group';
+import API from '@/services/api';
 
 describe('actions', () => {
   let injection;
@@ -6,7 +7,53 @@ describe('actions', () => {
   beforeEach(() => {
     injection = {
       dispatch: jest.fn(),
+      commit: jest.fn(),
+      getters: {
+        task: id => ({id, dueComplete: true})
+      },
     };
+  });
+
+  describe('updateTask', () => {
+    const taskId = 19;
+    const responseTask = {
+      id: taskId,
+      due: '05/04/1950'
+    };
+    let payload;
+
+    beforeEach(async () => {
+      API.tasks.update = jest.fn(() => responseTask);
+
+      payload = {id: taskId, due: '15/09/1911'};
+    });
+
+    it('update with early task', async () => {
+      await actions.updateTask(injection, payload);
+
+      const expectedPayload = {
+        ...injection.getters.task(taskId),
+        ...payload
+      };
+
+      expect(injection.commit).toHaveBeenNthCalledWith(1, 'updateTask', expectedPayload);
+    });
+
+    it('update with definitive task', async () => {
+      await actions.updateTask(injection, payload);
+
+      expect(injection.commit).toHaveBeenNthCalledWith(2, 'updateTask', responseTask);
+    });
+
+    it('restore initial task if api fail', async () => {
+      API.tasks.update = jest.fn(() => { throw Error(); });
+
+      await actions.updateTask(injection, payload);
+
+      expect(injection.commit).toHaveBeenNthCalledWith(
+        2, 'updateTask', injection.getters.task(taskId)
+      );
+    });
   });
 
   describe('markTaskAsComplete', () => {

--- a/tests/unit/services/store/modules/group/getters.spec.js
+++ b/tests/unit/services/store/modules/group/getters.spec.js
@@ -37,4 +37,23 @@ describe('getters', () => {
       expect(reducedResult).toStrictEqual([false, false, true, true]);
     });
   });
+
+  describe('task', () => {
+    it('returns tasks order by pos', () => {
+      const targetTask = {id: 11};
+
+      const state = {
+        group: {
+          cards: [
+            {id: 19},
+            targetTask,
+          ]
+        }
+      };
+
+      const task = getters.task(state, {tasks: state.group.cards})(targetTask.id);
+
+      expect(task).toEqual(targetTask);
+    });
+  });
 });


### PR DESCRIPTION
If the update fails, restore the original task